### PR TITLE
Add runtime uploads directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ frontend/node_modules/
 *.log
 .DS_Store
 .vscode/
+backend/uploads/

--- a/backend/src/middleware/upload.js
+++ b/backend/src/middleware/upload.js
@@ -1,8 +1,13 @@
+const fs = require('fs');
 const multer = require('multer');
 const path = require('path');
 
+// Ensure uploads directory exists at runtime
+const uploadDir = path.join(__dirname, '..', '..', 'uploads');
+fs.mkdirSync(uploadDir, { recursive: true });
+
 const storage = multer.diskStorage({
-  destination: (req, file, cb) => cb(null, 'uploads/'),
+  destination: (req, file, cb) => cb(null, uploadDir),
   filename: (req, file, cb) => {
     const ext = path.extname(file.originalname);
     cb(null, `${Date.now()}${ext}`);


### PR DESCRIPTION
## Summary
- ignore backend uploads directory
- create uploads directory automatically when the upload middleware loads

## Testing
- `npm test` in `backend` *(fails: Missing script)*
- `npm test` in `frontend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685bfba6cae083339c4e0ec6af836ff2